### PR TITLE
# 1.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.9.6
+
+- Fix outline on the user switcher if you had special color (dev,mvp,nitro,tournament winner)
+- Added win/loss/winrate to individual freelancer stats (Also works per map or all maps)
+- Added navbar on bottom of the previous games page
+
 # 1.9.5
 
 - Added Tournament games, shows only games in the tournament

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "1.9.3",
+  "name": "1.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evoslauncher",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evoslauncher",
-      "version": "1.9.5",
+      "version": "1.9.6",
       "hasInstallScript": true,
       "license": "MIT"
     }

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evoslauncher",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "A Atlas Reactor Launcher built with Electron, React",
   "license": "MIT",
   "author": {

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -77,7 +77,7 @@ p {
   border-radius: 1px;
 }
 
-.css-17idfle-MuiSelect-select-MuiInputBase-input-MuiInput-input.MuiSelect-select {
+.MuiSelect-select {
   overflow: unset !important;
 }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -389,7 +389,7 @@ export default function App() {
             <Route
               path="/tournament"
               element={page(
-                'dev',
+                'tournament',
                 <>
                   <NavBar />
                   <Box component="main" sx={{ flexGrow: 1, p: 0 }}>

--- a/src/renderer/components/stats/CharacterStatsChart.tsx
+++ b/src/renderer/components/stats/CharacterStatsChart.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { Bar } from 'react-chartjs-2';
 import 'chart.js/auto';
-import { Typography } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import ArrowForwardIosSharpIcon from '@mui/icons-material/ArrowForwardIosSharp';
 import MuiAccordion, { AccordionProps } from '@mui/material/Accordion';
@@ -14,6 +14,7 @@ import MuiAccordionDetails from '@mui/material/AccordionDetails';
 import { Chart } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { useTranslation } from 'react-i18next';
+import PlayerWinRate from './PlayerStatsWinRate';
 
 Chart.register(ChartDataLabels);
 Chart.defaults.set('plugins.datalabels', {
@@ -133,6 +134,8 @@ function CharacterChart({
 
 interface CharacterStatsChartProps {
   data: CharacterStats[];
+  player: string;
+  map: string;
 }
 
 const names = [
@@ -212,7 +215,7 @@ const categoryColors: { [key: string]: string } = {
   Support: 'rgba(75, 192, 192, 0.5)',
 };
 
-function CharacterStatsChart({ data }: CharacterStatsChartProps) {
+function CharacterStatsChart({ data, player, map }: CharacterStatsChartProps) {
   const { t } = useTranslation();
 
   const charactersByType = names.reduce((acc, character) => {
@@ -259,9 +262,24 @@ function CharacterStatsChart({ data }: CharacterStatsChartProps) {
                 <Typography
                   variant="h6"
                   sx={{ color: categoryColors[characterData.category] }}
+                  style={{ flex: 1 }} // Set the name to take up remaining space
                 >
                   {t(`charNames.${characterData.character.replace(/:3/g, '')}`)}
                 </Typography>
+                <div
+                  style={{
+                    width: '50%',
+                    color: categoryColors[characterData.category],
+                  }}
+                >
+                  <Grid container>
+                    <PlayerWinRate
+                      characterName={characterData.character}
+                      player={player}
+                      map={map}
+                    />
+                  </Grid>
+                </div>
               </AccordionSummary>
               <AccordionDetails>
                 <div

--- a/src/renderer/components/stats/GamesPlayedStats.tsx
+++ b/src/renderer/components/stats/GamesPlayedStats.tsx
@@ -61,5 +61,5 @@ export default function GamesPlayedStats({ map, player }: Props) {
     fetchData();
   }, [map, player]);
 
-  return <CharacterStatsChart data={gameData} />;
+  return <CharacterStatsChart data={gameData} player={player} map={map} />;
 }

--- a/src/renderer/components/stats/PreviousGamesPlayed.tsx
+++ b/src/renderer/components/stats/PreviousGamesPlayed.tsx
@@ -1025,7 +1025,8 @@ export default function PreviousGamesPlayed() {
               fullWidth
             />
           </Grid>
-          <Grid item xs={8}>
+          <Grid item xs={6} />
+          <Grid item xs={6}>
             <Pagination
               count={Math.ceil(total / pageSize)}
               page={currentPage}
@@ -1046,6 +1047,28 @@ export default function PreviousGamesPlayed() {
           i18n={i18n}
         />
       ))}
+      <Paper
+        elevation={3}
+        sx={{
+          borderBottom: 1,
+          borderColor: 'divider',
+          margin: '1em',
+          paddingBottom: '0px',
+          padding: '1em',
+        }}
+      >
+        <Grid container spacing={2}>
+          <Grid item xs={6} />
+          <Grid item xs={6}>
+            <Pagination
+              count={Math.ceil(total / pageSize)}
+              page={currentPage}
+              onChange={handlePageChange}
+              color="primary"
+            />
+          </Grid>
+        </Grid>
+      </Paper>
     </>
   );
 }


### PR DESCRIPTION
- Fix outline on the user switcher if you had special color (dev,mvp,nitro,tournament winner)
- Added win/loss/winrate to individual freelancer stats (Also works per map or all maps)
- Added navbar on bottom of the previous games page